### PR TITLE
improve diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,8 +170,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cfgrammar"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf74ea341ae8905eac9a234b6a5a845e118c25bbbdecf85ec77431a8b3bfa0be"
 dependencies = [
  "indexmap",
  "lazy_static",
@@ -637,8 +635,6 @@ dependencies = [
 [[package]]
 name = "lrlex"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b832738fbfa58ad036580929e973b3b6bd31c6d6c7f18f6b5ea7b626675c85"
 dependencies = [
  "getopts",
  "lazy_static",
@@ -653,8 +649,6 @@ dependencies = [
 [[package]]
 name = "lrpar"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f270b952b07995fe874b10a5ed7dd28c80aa2130e37a7de7ed667d034e0a521"
 dependencies = [
  "bincode",
  "cactus",
@@ -675,8 +669,6 @@ dependencies = [
 [[package]]
 name = "lrtable"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a854115c6a10772ac154261592b082436abc869c812575cadcf9d7ceda8eff0b"
 dependencies = [
  "cfgrammar",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
 name = "lrlex"
 version = "0.12.0"
 dependencies = [
+ "cfgrammar",
  "getopts",
  "lazy_static",
  "lrpar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,9 @@ members = [
   "toml",
   "xtask",
 ]
+
+[patch.crates-io]
+lrpar = { path = "../grmtools/lrpar" }
+lrlex = { path = "../grmtools/lrlex" }
+cfgrammar = { path = "../grmtools/cfgrammar" }
+lrtable = { path = "../grmtools/lrtable" }

--- a/server/src/parse_thread.rs
+++ b/server/src/parse_thread.rs
@@ -246,23 +246,23 @@ impl ParseThread {
                                                 if let Some(token_idx) = token_idx {
                                                     if let Some(span) = grm.token_span(token_idx) {
                                                         let start_line =
-                                                            yacc_file.contents.byte_to_line(span.0);
+                                                            yacc_file.contents.byte_to_line(span.start());
                                                         let start_line_char_idx = yacc_file
                                                             .contents
                                                             .line_to_char(start_line)
                                                             as u32;
                                                         let start_pos_char_idx =
-                                                            yacc_file.contents.byte_to_char(span.0)
+                                                            yacc_file.contents.byte_to_char(span.start())
                                                                 as u32;
 
                                                         let end_line =
-                                                            yacc_file.contents.byte_to_line(span.1);
+                                                            yacc_file.contents.byte_to_line(span.end());
                                                         let end_line_char_idx = yacc_file
                                                             .contents
                                                             .line_to_char(end_line)
                                                             as u32;
                                                         let end_pos_char_idx =
-                                                            yacc_file.contents.byte_to_char(span.1)
+                                                            yacc_file.contents.byte_to_char(span.end())
                                                                 as u32;
 
                                                         yacc_diags.push(lsp::Diagnostic {

--- a/server/src/parse_thread.rs
+++ b/server/src/parse_thread.rs
@@ -245,25 +245,29 @@ impl ParseThread {
                                                 let token_idx = grm.token_idx(token);
                                                 if let Some(token_idx) = token_idx {
                                                     if let Some(span) = grm.token_span(token_idx) {
-                                                        let start_line =
-                                                            yacc_file.contents.byte_to_line(span.start());
+                                                        let start_line = yacc_file
+                                                            .contents
+                                                            .byte_to_line(span.start());
                                                         let start_line_char_idx = yacc_file
                                                             .contents
                                                             .line_to_char(start_line)
                                                             as u32;
-                                                        let start_pos_char_idx =
-                                                            yacc_file.contents.byte_to_char(span.start())
-                                                                as u32;
+                                                        let start_pos_char_idx = yacc_file
+                                                            .contents
+                                                            .byte_to_char(span.start())
+                                                            as u32;
 
-                                                        let end_line =
-                                                            yacc_file.contents.byte_to_line(span.end());
+                                                        let end_line = yacc_file
+                                                            .contents
+                                                            .byte_to_line(span.end());
                                                         let end_line_char_idx = yacc_file
                                                             .contents
                                                             .line_to_char(end_line)
                                                             as u32;
-                                                        let end_pos_char_idx =
-                                                            yacc_file.contents.byte_to_char(span.end())
-                                                                as u32;
+                                                        let end_pos_char_idx = yacc_file
+                                                            .contents
+                                                            .byte_to_char(span.end())
+                                                            as u32;
 
                                                         yacc_diags.push(lsp::Diagnostic {
                                                             range: lsp::Range {

--- a/tests/badproject/src/sr.y
+++ b/tests/badproject/src/sr.y
@@ -1,5 +1,4 @@
 %start X
 %%
-
 X: | "A" Y;
 Y: X "A";

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -122,7 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
         readonly eventEmitter = new vscode.EventEmitter<vscode.Uri>();
         provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): vscode.ProviderResult<string> {
             if (uri.scheme == "nimbleparse_lsp") {
-                // Turn nimbleparse_lsp_cmd://command/path into a ServerDocumentRequest
+                // Turn nimbleparse_lsp_cmd://command/path_vscode_displays?path into a ServerDocumentRequest
                 let cmd = uri.authority;
                 let path = uri.query;
                 let params: ServerDocumentParams = { cmd: cmd, path: path};


### PR DESCRIPTION
This one currently depends upon  https://github.com/softdevteam/grmtools/pull/289
and may need to be updated based on any changes that come up in review.

currently this only tackles the `missing_from_lexer` diagnostic for which we can get span information.