### PR TITLE
add a TestKind for ron based test lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,7 @@ dependencies = [
  "nimbleparse_toml",
  "num-traits",
  "railroad",
+ "ron",
  "ropey",
  "serde",
  "serde-transcode",
@@ -1084,6 +1085,17 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ron"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
 
 [[package]]
 name = "ropey"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,7 @@ tokio-stream = "0.1.8"
 ropey = "1.4.1"
 railroad = "0.1.1"
 glob = "0.3.0"
+ron = "0.7.0"
 
 [dependencies.console-subscriber]
 version = "0.1.4"

--- a/toml/src/lib.rs
+++ b/toml/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Workspace {
     pub parsers: toml::Spanned<Vec<Parser>>,
-    pub tests: Vec<TestDir>,
+    pub tests: Vec<Test>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -37,11 +37,14 @@ fn default_recovery_kind() -> RecoveryKind {
 // We should consider having a trait for it...
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum TestKind {
+    // path of glob e.g. "tests/pass/**"
     Dir(String),
+    // path to a ron file format to be determined
+    RonTests(PathBuf),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TestDir {
+pub struct Test {
     pub kind: toml::Spanned<TestKind>,
     pub pass: bool,
 }


### PR DESCRIPTION
The general idea is this will eventually have a ron file like below for short tests,
as it can be annoying to have a bunch of really short files.

```
Tests(extension=".tdh", tests = [
"tom tom and tom",
r#"tom",
r#"
tom, dick and harry
"#,
""
])
```