### PR TITLE
work towards toml based tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +446,19 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "h2"
@@ -790,6 +812,7 @@ dependencies = [
  "cfgrammar",
  "console-subscriber",
  "glob",
+ "globset",
  "log",
  "lrlex",
  "lrpar",
@@ -805,6 +828,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "toml-spanned-value",
  "tower-lsp",
 ]
 
@@ -1402,6 +1426,16 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "toml-spanned-value"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1991312b7a0e66feb44bc16d97861c20ca476a3c6960bf888d25030dcf4d9f"
+dependencies = [
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,8 @@ tokio-stream = "0.1.8"
 ropey = "1.4.1"
 railroad = "0.1.1"
 glob = "0.3.0"
+toml-spanned-value = "0.1.0"
+globset = "0.4.8"
 
 [dependencies.console-subscriber]
 version = "0.1.4"

--- a/toml/src/lib.rs
+++ b/toml/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Workspace {
     pub parsers: toml::Spanned<Vec<Parser>>,
-    pub tests: Vec<TestDir>,
+    pub tests: Vec<Test>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -35,13 +35,20 @@ fn default_recovery_kind() -> RecoveryKind {
 // are source generators, and files which contain a list of strings each to be parsed as
 // it's own file... So the reason TestKind is like this is for future expansion.
 // We should consider having a trait for it...
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum TestKind {
+    // path of glob e.g. "tests/pass/**"
     Dir(String),
+    Toml {
+        /// Should match a Parser.extension
+        parser_extension: String,
+        /// An extension to be interpreted as toml tests
+        toml_test_extension: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TestDir {
+pub struct Test {
     pub kind: toml::Spanned<TestKind>,
     pub pass: bool,
 }


### PR DESCRIPTION
supersedes #20 

This will eventually be similar to below for tests of the form:
```
[tests]
extension = ".foo",
tests = ["some sources",
'''
multi
line
sources
'''
]
```

I.e. arrays of source snippets we want to parse but are so short putting them all in their own individual files becomes annoying.  This may or may not go back to being ron based as in #20 (I prefer ron's rust-like strings) but currently we can't get at spans for ron easily.  Whatever format we eventually choose most of the code will end up being shared anyways.

Edit:
One thing I really don't like about this form, is that it means parsing the toml/ron/whatever twice,
once to pull out the extension for routing, and once to pull out the actual data.
I think ideally there would be a way to just partially parse this e.g. via `#![attribute(file_extension = ".foo")]` or perhaps more familiar `#![cfg(file_extension = ".foo")]`

Two things I really don't like about is if you change the extension in the data file, you must find some way to invalidate the old extension, which could be routed to a completely different parser, so In theory main is going to have a map for each test list so it can even notice the extension has changed.