### PR TITLE
Remove unnecessary `&mut self` to updated_lex_or_yacc_file.

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,6 +10,8 @@ use tower_lsp::lsp_types as lsp;
 use std::ops::DerefMut as _;
 use tokio_stream::StreamExt as _;
 
+use std::path::Path;
+
 #[derive(thiserror::Error, Debug)]
 enum ServerError {
     #[error("argument requires a path")]
@@ -62,6 +64,12 @@ pub struct ParserInfo {
 }
 
 impl ParserInfo {
+    fn is_lexer(&self, path: &Path) -> bool {
+        self.l_path == path
+    }
+    fn is_parser(&self, path: &Path) -> bool {
+        self.y_path == path
+    }
     fn id(&self) -> ParserId {
         self.id
     }

--- a/server/src/parse_thread.rs
+++ b/server/src/parse_thread.rs
@@ -242,7 +242,7 @@ impl ParseThread {
         self.workspace_path.join(path)
     }
     fn updated_lex_or_yacc_file(
-        self: &mut ParseThread,
+        self: &ParseThread,
         change_set: &mut std::collections::HashSet<TestReparse>,
         files: &std::collections::HashMap<std::path::PathBuf, File>,
         stuff: &mut Option<(

--- a/server/src/parse_thread.rs
+++ b/server/src/parse_thread.rs
@@ -889,7 +889,7 @@ impl ParseThread {
                                 files.insert(File {
                                     #[cfg(feature = "debug_stuff")]
                                     output: self.output.clone(),
-                                    path: params.text_document.uri.to_file_path().clone().unwrap(),
+                                    path: path.clone(),
                                     contents: rope::Rope::from(params.text_document.text),
                                     version: Some(params.text_document.version),
                                 });

--- a/server/src/parse_thread.rs
+++ b/server/src/parse_thread.rs
@@ -104,10 +104,10 @@ impl<T: fmt::Display> fmt::Display for CommaSep<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let mut iter = self.stuff.iter();
         if let Some(item) = iter.next() {
-            formatter.write_fmt(format_args!("'{}'", item))?;
+            formatter.write_fmt(format_args!("'{item}'"))?;
         }
         for item in iter {
-            formatter.write_fmt(format_args!(", '{}'", item))?;
+            formatter.write_fmt(format_args!(", '{item}'"))?;
         }
         Ok(())
     }
@@ -550,7 +550,7 @@ impl ParseThread {
                                                         lex_diags.push(lsp::Diagnostic {
                                                             range: lex_file.span_to_range(rule.name_span),
                                                             severity: Some(lsp::DiagnosticSeverity::WARNING),
-                                                            message: format!("token '{}' is defined in the lexer but not referenced in the grammar.", token),
+                                                            message: format!("token '{token}' is defined in the lexer but not referenced in the grammar."),
                                                             ..Default::default()
                                                         });
                                                     }
@@ -571,7 +571,7 @@ impl ParseThread {
                                                         yacc_diags.push(lsp::Diagnostic {
                                                             range: yacc_file.span_to_range(span),
                                                             severity: Some(lsp::DiagnosticSeverity::ERROR),
-                                                            message: format!("the token '{}' is referenced in the grammar but not defined in the lexer.", token),
+                                                            message: format!("the token '{token}' is referenced in the grammar but not defined in the lexer."),
                                                             ..Default::default()
                                                         });
                                                     }
@@ -943,8 +943,7 @@ impl ParseThread {
                                         if let Some(range) = change.range {
                                             self.output
                                                 .send(ParserMsg::Info(format!(
-                                                    "did change: {:?} {:?}",
-                                                    path, range
+                                                    "did change: {path:?} {range:?}"
                                                 )))
                                                 .unwrap();
                                             let start_line_charidx =
@@ -1167,8 +1166,7 @@ impl ParseThread {
                         let n = change_set.len();
                         self.output
                             .send(ParserMsg::Info(format!(
-                                "Evaluating changes {:?}",
-                                change_set
+                                "Evaluating changes {change_set:?}"
                             )))
                             .unwrap();
 


### PR DESCRIPTION
This should in theory allow for some further cleanup, as I believe it was stopping us from refactoring some stuff out into functions.

Probably wait to merge until these changes are finished